### PR TITLE
Ability to define local internal options for wazuh manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Wazuh Helm Chart
 
-![Version: 0.0.3](https://img.shields.io/badge/Version-0.0.2-informational?style=flat-square)
+![Version: 0.0.4](https://img.shields.io/badge/Version-0.0.4-informational?style=flat-square)
 ![AppVersion: 4.10.1](https://img.shields.io/badge/AppVersion-4.10.1-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/wazuh-helm)](https://artifacthub.io/packages/search?repo=wazuh-helm)
 

--- a/charts/wazuh/Chart.yaml
+++ b/charts/wazuh/Chart.yaml
@@ -3,7 +3,7 @@ name: wazuh
 description: Wazuh is a free and open source security platform that unifies XDR and SIEM protection for endpoints and cloud workloads.
 type: application
 appVersion: 4.10.1
-version: 0.0.3
+version: 0.0.4
 home: https://wazuh.com/
 sources:
   - https://github.com/promptlylabs/wazuh-helm-chart
@@ -29,7 +29,7 @@ annotations:
   artifacthub.io/category: security
   artifacthub.io/changes: |
     - kind: added
-      description: Ingresses for Agent registration and communication
+      description: Internal Options for Wazuh can now be configured
   artifacthub.io/links: |
     - name: application source
       url: https://github.com/wazuh/wazuh

--- a/charts/wazuh/README.md
+++ b/charts/wazuh/README.md
@@ -1,6 +1,6 @@
 # Wazuh Helm Chart
 
-![Version: 0.0.3](https://img.shields.io/badge/Version-0.0.2-informational?style=flat-square)
+![Version: 0.0.4](https://img.shields.io/badge/Version-0.0.4-informational?style=flat-square)
 ![AppVersion: 4.10.1](https://img.shields.io/badge/AppVersion-4.10.1-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/wazuh-helm)](https://artifacthub.io/packages/search?repo=wazuh-helm)
 

--- a/charts/wazuh/templates/_helpers.tpl
+++ b/charts/wazuh/templates/_helpers.tpl
@@ -384,6 +384,19 @@ uiSettings.overrides.defaultRoute: /app/wz-home
 </ossec_config>
 {{- end }}
 
+{{- define "wazuh.master.local_internal_options" }}
+# local_internal_options.conf
+#
+# This file should be handled with care. It contains
+# run time modifications that can affect the use
+# of OSSEC. Only change it if you know what you
+# are doing. Look first at ossec.conf
+# for most of the things you want to change.
+#
+# This file will not be overwritten during upgrades.
+vulnerability-detection.disable_scan_manager=0
+{{- end }}
+
 {{/* Snippet for the configuration file used by wazuh worker */}}
 {{- define "wazuh.worker.conf" }}
 <!--
@@ -733,7 +746,20 @@ uiSettings.overrides.defaultRoute: /app/wz-home
 </ossec_config>
 {{- end }}
 
-{{- define "wazuh.indexer.opensearchConfig"}}
+{{- define "wazuh.worker.local_internal_options" }}
+# local_internal_options.conf
+#
+# This file should be handled with care. It contains
+# run time modifications that can affect the use
+# of OSSEC. Only change it if you know what you
+# are doing. Look first at ossec.conf
+# for most of the things you want to change.
+#
+# This file will not be overwritten during upgrades.
+vulnerability-detection.disable_scan_manager=0
+{{- end }}
+
+{{- define "wazuh.indexer.opensearchConfig" }}
 cluster.name: ${CLUSTER_NAME}
 node.name: ${NODE_NAME}
 network.host: ${NETWORK_HOST}

--- a/charts/wazuh/templates/manager/configmap.yaml
+++ b/charts/wazuh/templates/manager/configmap.yaml
@@ -11,5 +11,9 @@ data:
     sed -i "s/___INDEX___/$node_index/g" /wazuh-config-mount/etc/ossec.conf
   master.conf: |
     {{- tpl .Values.wazuh.master.conf . | indent 2 }}
+  master_local_internal_options.conf: |
+    {{- tpl .Values.wazuh.master.localInternalOptions . | indent 2 }}
   worker.conf: |
     {{- tpl .Values.wazuh.worker.conf . | indent 2 }}
+  worker_local_internal_options.conf: |
+    {{- tpl .Values.wazuh.worker.localInternalOptions . | indent 2 }}

--- a/charts/wazuh/templates/manager/master/statefulset.yaml
+++ b/charts/wazuh/templates/manager/master/statefulset.yaml
@@ -42,8 +42,8 @@ spec:
         - name: wazuh-authd-pass
           secret:
             secretName: wazuh-authd-pass
-        - emptyDir: {}
-          name: result-config
+        - name: result-config
+          emptyDir: {}
       {{ with .Values.imagePullSecrets -}}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -80,6 +80,10 @@ spec:
             # Wazuh Config
             - mountPath: /wazuh-config-mount/etc/
               name: result-config
+            - mountPath: /var/ossec/etc/local_internal_options.conf
+              name: config
+              readOnly: true
+              subPath: master_local_internal_options.conf
             # Certs
             - mountPath: /etc/ssl/root-ca.pem
               name: filebeat-certs

--- a/charts/wazuh/templates/manager/worker/statefulset.yaml
+++ b/charts/wazuh/templates/manager/worker/statefulset.yaml
@@ -87,6 +87,10 @@ spec:
             # Wazuh config
             - mountPath: /wazuh-config-mount/etc/
               name: result-config
+            - mountPath: /var/ossec/etc/local_internal_options.conf
+              name: config
+              readOnly: true
+              subPath: master_local_internal_options.conf
             # Certs
             - mountPath: /etc/ssl/root-ca.pem
               name: filebeat-certs

--- a/charts/wazuh/values.yaml
+++ b/charts/wazuh/values.yaml
@@ -236,6 +236,8 @@ wazuh:
       {{- include "wazuh.master.conf" . | indent 2 -}}
     # To be appended to the master.conf
     extraConf: ""
+    localInternalOptions: |
+      {{- include "wazuh.master.local_internal_options" . | indent 2 -}}
 
   worker:
     replicas: 2
@@ -285,3 +287,5 @@ wazuh:
       {{- include "wazuh.worker.conf" . | indent 2 -}}
     # To be appended to the worker.conf
     extraConf: ""
+    localInternalOptions: |
+      {{- include "wazuh.worker.local_internal_options" . | indent 2 -}}


### PR DESCRIPTION
https://documentation.wazuh.com/current/user-manual/reference/internal-options.html

> ## Internal configuration
> 
> The main configuration is located in the `ossec.conf` file, however some internal configuration features are located in the `/var/ossec/etc/internal_options.conf` file.
> 
> Generally, this file is reserved for debugging issues and for troubleshooting. Any error in this file may cause your installation to malfunction or fail to run.
> 
> ⚠️ Warning This file will be overwritten during upgrades. In order to maintain custom changes, you must use the `/var/ossec/etc/local_internal_options.conf` file.