### PR TITLE
Remove quotation marks from indexer host on manager config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Wazuh Helm Chart
 
-![Version: 0.0.4](https://img.shields.io/badge/Version-0.0.4-informational?style=flat-square)
+![Version: 0.0.5](https://img.shields.io/badge/Version-0.0.5-informational?style=flat-square)
 ![AppVersion: 4.10.1](https://img.shields.io/badge/AppVersion-4.10.1-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/wazuh-helm)](https://artifacthub.io/packages/search?repo=wazuh-helm)
 

--- a/charts/wazuh/Chart.yaml
+++ b/charts/wazuh/Chart.yaml
@@ -3,7 +3,7 @@ name: wazuh
 description: Wazuh is a free and open source security platform that unifies XDR and SIEM protection for endpoints and cloud workloads.
 type: application
 appVersion: 4.10.1
-version: 0.0.4
+version: 0.0.5
 home: https://wazuh.com/
 sources:
   - https://github.com/promptlylabs/wazuh-helm-chart
@@ -28,8 +28,8 @@ dependencies:
 annotations:
   artifacthub.io/category: security
   artifacthub.io/changes: |
-    - kind: added
-      description: Internal Options for Wazuh can now be configured
+    - kind: fixed
+      description: Indexer host URL on Manager configuration file - removed quotation marks. Vulnerability Detection page is now working
   artifacthub.io/links: |
     - name: application source
       url: https://github.com/wazuh/wazuh

--- a/charts/wazuh/README.md
+++ b/charts/wazuh/README.md
@@ -1,6 +1,6 @@
 # Wazuh Helm Chart
 
-![Version: 0.0.4](https://img.shields.io/badge/Version-0.0.4-informational?style=flat-square)
+![Version: 0.0.5](https://img.shields.io/badge/Version-0.0.5-informational?style=flat-square)
 ![AppVersion: 4.10.1](https://img.shields.io/badge/AppVersion-4.10.1-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/wazuh-helm)](https://artifacthub.io/packages/search?repo=wazuh-helm)
 

--- a/charts/wazuh/templates/_helpers.tpl
+++ b/charts/wazuh/templates/_helpers.tpl
@@ -72,7 +72,7 @@ uiSettings.overrides.defaultRoute: /app/wz-home
 
   <!-- Choose between "plain", "json", or "plain,json" for the format of internal logs -->
   <logging>
-    <log_format>plain</log_format>
+    <log_format>json</log_format>
   </logging>
 
   <remote>
@@ -154,7 +154,7 @@ uiSettings.overrides.defaultRoute: /app/wz-home
   <indexer>
     <enabled>yes</enabled>
     <hosts>
-      <host>"https://indexer:{{ .Values.indexer.service.httpPort }}"</host>
+      <host>https://indexer:{{ .Values.indexer.service.httpPort }}</host>
     </hosts>
     <ssl>
       <certificate_authorities>
@@ -431,7 +431,7 @@ vulnerability-detection.disable_scan_manager=0
 
   <!-- Choose between "plain", "json", or "plain,json" for the format of internal logs -->
   <logging>
-    <log_format>plain</log_format>
+    <log_format>json</log_format>
   </logging>
 
   <remote>
@@ -513,7 +513,7 @@ vulnerability-detection.disable_scan_manager=0
   <indexer>
     <enabled>yes</enabled>
     <hosts>
-      <host>"https://indexer:{{ .Values.indexer.service.httpPort }}"</host>
+      <host>https://indexer:{{ .Values.indexer.service.httpPort }}</host>
     </hosts>
     <ssl>
       <certificate_authorities>


### PR DESCRIPTION
For the Vulnerability Detection feature, the Wazuh manager was not able to correctly connect itself to the Indexer. The host value was not correctly parsed because of extra quotation marks ("").

These were removed.

Discussion/Debugging Slack Thread: https://wazuh.slack.com/archives/C0A933R8E/p1739378182809319