### PR TITLE
Adds helper declaration for wazuh.yml config

### DIFF
--- a/charts/wazuh/templates/_helpers.tpl
+++ b/charts/wazuh/templates/_helpers.tpl
@@ -852,3 +852,169 @@ snapshotrestore:
   - "snapshotrestore"
   description: "Demo snapshotrestore user"
 {{- end }}
+
+{{- define "wazuh.dashboard.wazuh_config"}}
+---
+#
+# Wazuh app - App configuration file
+# Copyright (C) 2017, Wazuh Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# Find more information about this on the LICENSE file.
+#
+# ======================== Wazuh app configuration file ========================
+#
+# Please check the documentation for more information on configuration options:
+# https://documentation.wazuh.com/current/installation-guide/index.html
+#
+# Also, you can check our repository:
+# https://github.com/wazuh/wazuh-dashboard-plugins
+#
+# ------------------------------- Index patterns -------------------------------
+#
+# Default index pattern to use.
+#pattern: wazuh-alerts-*
+#
+# ----------------------------------- Checks -----------------------------------
+#
+# Defines which checks must to be consider by the healthcheck
+# step once the Wazuh app starts. Values must to be true or false.
+#checks.pattern : true
+#checks.template: true
+#checks.api     : true
+#checks.setup   : true
+#checks.metaFields: true
+#
+# --------------------------------- Extensions ---------------------------------
+#
+# Defines which extensions should be activated when you add a new API entry.
+# You can change them after Wazuh app starts.
+# Values must to be true or false.
+#extensions.pci       : true
+#extensions.gdpr      : true
+#extensions.hipaa     : true
+#extensions.nist      : true
+#extensions.tsc       : true
+#extensions.audit     : true
+#extensions.oscap     : false
+#extensions.ciscat    : false
+#extensions.aws       : false
+#extensions.gcp       : false
+#extensions.virustotal: false
+#extensions.osquery   : false
+#extensions.docker    : false
+#
+# ---------------------------------- Time out ----------------------------------
+#
+# Defines maximum timeout to be used on the Wazuh app requests.
+# It will be ignored if it is bellow 1500.
+# It means milliseconds before we consider a request as failed.
+# Default: 20000
+#timeout: 20000
+#
+# -------------------------------- API selector --------------------------------
+#
+# Defines if the user is allowed to change the selected
+# API directly from the Wazuh app top menu.
+# Default: true
+#api.selector: true
+#
+# --------------------------- Index pattern selector ---------------------------
+#
+# Defines if the user is allowed to change the selected
+# index pattern directly from the Wazuh app top menu.
+# Default: true
+#ip.selector: true
+#
+# List of index patterns to be ignored
+#ip.ignore: []
+#
+# ------------------------------ wazuh-monitoring ------------------------------
+#
+# Custom setting to enable/disable wazuh-monitoring indices.
+# Values: true, false, worker
+# If worker is given as value, the app will show the Agents status
+# visualization but won't insert data on wazuh-monitoring indices.
+# Default: true
+#wazuh.monitoring.enabled: true
+#
+# Custom setting to set the frequency for wazuh-monitoring indices cron task.
+# Default: 900 (s)
+#wazuh.monitoring.frequency: 900
+#
+# Configure wazuh-monitoring-* indices shards and replicas.
+#wazuh.monitoring.shards: 2
+#wazuh.monitoring.replicas: 0
+#
+# Configure wazuh-monitoring-* indices custom creation interval.
+# Values: h (hourly), d (daily), w (weekly), m (monthly)
+# Default: d
+#wazuh.monitoring.creation: d
+#
+# Default index pattern to use for Wazuh monitoring
+#wazuh.monitoring.pattern: wazuh-monitoring-*
+#
+# --------------------------------- wazuh-cron ----------------------------------
+#
+# Customize the index prefix of predefined jobs
+# This change is not retroactive, if you change it new indexes will be created
+# cron.prefix: test
+#
+# ------------------------------ wazuh-statistics -------------------------------
+#
+# Custom setting to enable/disable statistics tasks.
+#cron.statistics.status: true
+#
+# Enter the ID of the APIs you want to save data from, leave this empty to run
+# the task on all configured APIs
+#cron.statistics.apis: []
+#
+# Define the frequency of task execution using cron schedule expressions
+#cron.statistics.interval: 0 0 * * * *
+#
+# Define the name of the index in which the documents are to be saved.
+#cron.statistics.index.name: statistics
+#
+# Define the interval in which the index will be created
+#cron.statistics.index.creation: w
+#
+# ------------------------------- App privileges --------------------------------
+#admin: true
+#
+# ---------------------------- Hide manager alerts ------------------------------
+# Hide the alerts of the manager in all dashboards and discover
+#hideManagerAlerts: false
+#
+# ------------------------------- App logging level -----------------------------
+# Set the logging level for the Wazuh App log files.
+# Default value: info
+# Allowed values: info, debug
+#logs.level: info
+#
+# -------------------------------- Enrollment DNS -------------------------------
+# Set the variable WAZUH_REGISTRATION_SERVER in agents deployment.
+# Default value: ''
+#enrollment.dns: ''
+#
+#-------------------------------- API entries -----------------------------------
+#The following configuration is the default structure to define an API entry.
+#
+#hosts:
+#  - <id>:
+#     url: http(s)://<url>
+#     port: <port>
+#     username: <username>
+#     password: <password>
+hosts:
+  - 1513629884013:
+      url: https://wazuh
+      port: 55000
+      username: {{ .Values.wazuh.apiCred.username }}
+      password: {{ .Values.wazuh.apiCred.password }}
+      run_as: true
+
+{{- end }}

--- a/charts/wazuh/templates/dashboard/configmap.yaml
+++ b/charts/wazuh/templates/dashboard/configmap.yaml
@@ -9,3 +9,5 @@ metadata:
 data:
   opensearch_dashboards.yml: |
     {{- tpl .Values.dashboard.config . | indent 2 }}
+  wazuh.yml: |
+    {{- tpl .Values.dashboard.wazuh_config . | indent 2 }}

--- a/charts/wazuh/templates/dashboard/deployment.yaml
+++ b/charts/wazuh/templates/dashboard/deployment.yaml
@@ -48,6 +48,10 @@ spec:
               name: config
               readOnly: false
               subPath: opensearch_dashboards.yml
+            - mountPath: /usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml
+              name: config
+              readOnly: false
+              subPath: wazuh.yml
             # Certs
             - mountPath: /usr/share/wazuh-dashboard/certs/cert.pem
               name: dashboard-certs

--- a/charts/wazuh/values.yaml
+++ b/charts/wazuh/values.yaml
@@ -55,6 +55,8 @@ dashboard:
   
   config: |
     {{- include "wazuh.dashboard.config" . | indent 2 -}}
+  wazuh_config: |
+    {{- include "wazuh.dashboard.wazuh_config" . | indent 2 -}}
   
   ingress:
     enabled: false


### PR DESCRIPTION
I've come across an issue when attempting to configure the provided helm chart to support multi-tenancy. There is currently no way to override the contents of `/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml` without building a custom container image which is far from ideal. 

This is necessary to enable the `run_as` setting which is a hard requirement for multi-tenancy.

The part that might need some refinement is the choice of value. Right now it assumes that you are assigning the usename and password in plaintext in the values.yml file and does not account for using an existing secret.

Relates to issue: https://github.com/promptlylabs/wazuh-helm-chart/issues/8